### PR TITLE
Update discord.py version to current newest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ configargparse
 python-dateutil
 requests
 tabulate
-discord.py==1.1.1
+discord.py==1.3.4


### PR DESCRIPTION
On discord.py==1.1.1 the bot doesn't go online anymore and starting MADevice is followed by an error:

```python3
Task exception was never retrieved
future: <Task finished coro=<Client.run.<locals>.runner() done, defined at /home/ubuntu/MADevice/py3/lib/python3.6/site-packages/discord/client.py:545> exception=TypeError("__new__() got an unexpected keyword argument 'deny_new'",)>
Traceback (most recent call last):
  File "/home/ubuntu/MADevice/py3/lib/python3.6/site-packages/discord/client.py", line 547, in runner
    await self.start(*args, **kwargs)
  File "/home/ubuntu/MADevice/py3/lib/python3.6/site-packages/discord/client.py", line 511, in start
    await self.connect(reconnect=reconnect)
  File "/home/ubuntu/MADevice/py3/lib/python3.6/site-packages/discord/client.py", line 433, in connect
    await self._connect()
  File "/home/ubuntu/MADevice/py3/lib/python3.6/site-packages/discord/client.py", line 397, in _connect
    await self.ws.poll_event()
  File "/home/ubuntu/MADevice/py3/lib/python3.6/site-packages/discord/gateway.py", line 470, in poll_event
    await self.received_message(msg)
  File "/home/ubuntu/MADevice/py3/lib/python3.6/site-packages/discord/gateway.py", line 424, in received_message
    func(data)
  File "/home/ubuntu/MADevice/py3/lib/python3.6/site-packages/discord/state.py", line 664, in parse_guild_create
    guild = self._get_create_guild(data)
  File "/home/ubuntu/MADevice/py3/lib/python3.6/site-packages/discord/state.py", line 639, in _get_create_guild
    guild._from_data(data)
  File "/home/ubuntu/MADevice/py3/lib/python3.6/site-packages/discord/guild.py", line 246, in _from_data
    self._sync(guild)
  File "/home/ubuntu/MADevice/py3/lib/python3.6/site-packages/discord/guild.py", line 273, in _sync
    self._add_channel(TextChannel(guild=self, data=c, state=self._state))
  File "/home/ubuntu/MADevice/py3/lib/python3.6/site-packages/discord/channel.py", line 107, in __init__
    self._update(guild, data)
  File "/home/ubuntu/MADevice/py3/lib/python3.6/site-packages/discord/channel.py", line 123, in _update
    self._fill_overwrites(data)
  File "/home/ubuntu/MADevice/py3/lib/python3.6/site-packages/discord/abc.py", line 271, in _fill_overwrites
    self._overwrites.append(_Overwrites(id=overridden_id, **overridden))
TypeError: __new__() got an unexpected keyword argument 'deny_new'
```